### PR TITLE
fix: resolve issue #11 extension compatibility with Code 1.108+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .vscode-test/
 *.vsix
+
+/.codex/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "formalist",
   "displayName": "formalist",
   "description": "Make R code properly formatted",
-  "version": "0.2.3",
+  "version": "0.2.3-1",
   "publisher": "atsyplenkov",
   "license": "MIT",
   "pricing": "Free",
@@ -20,7 +20,7 @@
   },
   "engines": {
     "positron": ">=2025.01.0",
-    "vscode": "1.106.0"
+    "vscode": "^1.106.0"
   },
   "categories": [
     "Other",

--- a/test/manifest-engine.test.js
+++ b/test/manifest-engine.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const manifest = require('../package.json');
+
+assert.notStrictEqual(
+	manifest.engines.vscode,
+	'1.106.0',
+	'engines.vscode must be a semver range, not an exact version'
+);
+
+assert.match(
+	manifest.engines.vscode,
+	/^[\^>~]/,
+	'engines.vscode should use a range operator such as ^, >=, or ~'
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,10 +136,10 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/vscode@^1.93.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.107.0.tgz#82d76dec334896b4ce8373c6042549623e494105"
-  integrity sha512-XS8YE1jlyTIowP64+HoN30OlC1H9xqSlq1eoLZUgFEC8oUTO6euYZxti1xRiLSfZocs4qytTzR6xCBYtioQTCg==
+"@types/vscode@^1.106.0":
+  version "1.109.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.109.0.tgz#062dfddf5f7df9cf36038e900ae67421ae69091b"
+  integrity sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.1"


### PR DESCRIPTION
## Summary
- change `engines.vscode` from exact `1.106.0` to semver range `^1.106.0`
- add regression test `test/manifest-engine.test.js` to prevent exact pinning
- bump extension version to `0.2.3-1` to mark this patch-only build

## Why
Issue #11 reports marketplace rejection in Positron 2026.03.0 with message: "Extension is not compatible with Code 1.108.0". Exact engine pin blocks newer Code builds.

## Validation
- `node test/manifest-engine.test.js`
- `corepack yarn lint` (passes with existing pre-existing warning in `src/fixLint.js`)
- `corepack yarn test` (1 passing)

Closes #11
